### PR TITLE
Fix installation script reliability and improve error handling

### DIFF
--- a/scripts/install-krita-with-segmentation.sh
+++ b/scripts/install-krita-with-segmentation.sh
@@ -1,42 +1,59 @@
 #!/bin/sh
+set -e  # Exit on error
+
 echo "Installing Krita to ~/.Applications/Krita (hidden in your home directory)"
 INSTALL_DIR=~/.Applications/Krita
 mkdir -p "$INSTALL_DIR"
 cd "$INSTALL_DIR"
 
 echo "Getting the latest download for Krita and Segmentation Tools"
-BASE_KRITA_URL="https://binary-factory.kde.org/job/Krita_Stable_Appimage_Build/lastSuccessfulBuild/artifact/"
-KRITA_PAGE=$(curl -s $BASE_KRITA_URL)
-LATEST_KRITA_APPIMAGE=$(echo "$KRITA_PAGE" | grep -o 'krita-.*\.appimage"' | head -1 | sed 's/"$//')
-LATEST_PLUGIN=$(curl -s https://api.github.com/repos/Acly/krita-ai-tools/releases/latest | grep browser_download_url | grep tar.gz | cut -d '"' -f 4)
+KRITA_VERSION="5.2.6"
+KRITA_URL="https://download.kde.org/stable/krita/${KRITA_VERSION}/krita-${KRITA_VERSION}-x86_64.appimage"
+KRITA_FILENAME="krita-${KRITA_VERSION}-x86_64.appimage"
 
-echo "Checking to see if your version of Krita is up to date?"
-if [ ! -f "$LATEST_KRITA_APPIMAGE" ]; then
+if [ ! -f "$KRITA_FILENAME" ]; then
     echo "Downloading new Krita"
-    wget -O "$LATEST_KRITA_APPIMAGE" "${BASE_KRITA_URL}${LATEST_KRITA_APPIMAGE}"
-    chmod +x "$LATEST_KRITA_APPIMAGE"
-    "./$LATEST_KRITA_APPIMAGE" --appimage-extract
+    wget -O "$KRITA_FILENAME" "$KRITA_URL"
+    chmod +x "$KRITA_FILENAME"
+    
+    echo "Extracting AppImage..."
+    if [ -d "squashfs-root" ]; then
+        echo "Removing existing squashfs-root directory..."
+        rm -rf squashfs-root
+    fi
+    "./$KRITA_FILENAME" --appimage-extract
 else
     echo "Latest Krita is already installed; moving on."
+fi
+
+if [ ! -d "squashfs-root" ]; then
+    echo "Error: AppImage extraction failed - squashfs-root directory not found"
+    exit 1
 fi
 
 echo "Updating the desktop file with correct paths"
 EXTRACTED_DESKTOP_FILE="$INSTALL_DIR/squashfs-root/org.kde.krita.desktop"
 ICON_PATH="$INSTALL_DIR/squashfs-root/krita.png"
+
 if [ -f "$EXTRACTED_DESKTOP_FILE" ]; then
     echo "Pointing shortcut to Krita and tools"
-    sed -i 's|^Exec=.*|Exec=env APPDIR='$INSTALL_DIR'/squashfs-root APPIMAGE=1 '$INSTALL_DIR'/squashfs-root/AppRun %U|' "$EXTRACTED_DESKTOP_FILE"
-    sed -i 's|^Icon=.*|Icon='$ICON_PATH'|' "$EXTRACTED_DESKTOP_FILE"
+    sed -i "s|^Exec=.*|Exec=env APPDIR='$INSTALL_DIR/squashfs-root' APPIMAGE=1 '$INSTALL_DIR/squashfs-root/AppRun' %U|" "$EXTRACTED_DESKTOP_FILE"
+    sed -i "s|^Icon=.*|Icon=$ICON_PATH|" "$EXTRACTED_DESKTOP_FILE"
+    mkdir -p ~/.local/share/applications/
     cp "$EXTRACTED_DESKTOP_FILE" ~/.local/share/applications/
 else
-    echo "Extracted desktop file not found, it could have been moved."
+    echo "Error: Extracted desktop file not found at $EXTRACTED_DESKTOP_FILE"
+    exit 1
 fi
 
 echo "Checking if segmentation plugin is outdated"
-if [ ! -f "$(basename "$LATEST_PLUGIN")" ]; then
+LATEST_PLUGIN=$(curl -s https://api.github.com/repos/Acly/krita-ai-tools/releases/latest | grep browser_download_url | grep tar.gz | cut -d '"' -f 4)
+PLUGIN_FILENAME=$(basename "$LATEST_PLUGIN")
+
+if [ ! -f "$PLUGIN_FILENAME" ]; then
     echo "Downloading new plugin"
-    wget -O "$(basename "$LATEST_PLUGIN")" "$LATEST_PLUGIN"
-    tar -xf "$(basename "$LATEST_PLUGIN")" -C squashfs-root/
+    wget -O "$PLUGIN_FILENAME" "$LATEST_PLUGIN"
+    tar -xf "$PLUGIN_FILENAME" -C squashfs-root/
 else
     echo "Latest segmentation plugin is already installed."
 fi

--- a/scripts/install-krita-with-segmentation.sh
+++ b/scripts/install-krita-with-segmentation.sh
@@ -7,15 +7,48 @@ mkdir -p "$INSTALL_DIR"
 cd "$INSTALL_DIR"
 
 echo "Getting the latest download for Krita and Segmentation Tools"
-KRITA_VERSION="5.2.6"
-KRITA_URL="https://download.kde.org/stable/krita/${KRITA_VERSION}/krita-${KRITA_VERSION}-x86_64.appimage"
+# Known good fallback version
+FALLBACK_VERSION="5.2.6"
+
+# Try to detect latest version from KDE's stable directory
+echo "Attempting to detect latest Krita version..."
+KRITA_VERSION=$(curl -s https://download.kde.org/stable/krita/ | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | sort -V | tail -n1)
+if [ -z "$KRITA_VERSION" ]; then
+    echo "Failed to detect latest version from stable directory"
+    echo "Checking Attic for latest version..."
+    KRITA_VERSION=$(curl -s https://download.kde.org/Attic/krita/ | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | sort -V | tail -n1)
+    if [ -z "$KRITA_VERSION" ]; then
+        # this doesn't really make sense because the version would've been detected in the previous grep magic but alas
+        echo "Warning: Could not detect Krita version, falling back to version $FALLBACK_VERSION"
+        KRITA_VERSION=$FALLBACK_VERSION
+        BASE_URL="https://download.kde.org/Attic/krita"
+    else
+        BASE_URL="https://download.kde.org/Attic/krita"
+    fi
+else
+    BASE_URL="https://download.kde.org/stable/krita"
+fi
+
+KRITA_URL="${BASE_URL}/${KRITA_VERSION}/krita-${KRITA_VERSION}-x86_64.appimage"
 KRITA_FILENAME="krita-${KRITA_VERSION}-x86_64.appimage"
 
+echo "Debug: Using Krita version: $KRITA_VERSION"
+echo "Debug: Download URL: $KRITA_URL"
+
+# Verify URL exists before downloading
+if ! curl --output /dev/null --silent --head --fail "$KRITA_URL"; then
+    echo "Warning: URL not accessible, falling back to version $FALLBACK_VERSION"
+    KRITA_VERSION=$FALLBACK_VERSION
+    KRITA_URL="https://download.kde.org/Attic/krita/${FALLBACK_VERSION}/krita-${FALLBACK_VERSION}-x86_64.appimage"
+    KRITA_FILENAME="krita-${FALLBACK_VERSION}-x86_64.appimage"
+fi
+
+# Download Krita
 if [ ! -f "$KRITA_FILENAME" ]; then
     echo "Downloading new Krita"
     wget -O "$KRITA_FILENAME" "$KRITA_URL"
     chmod +x "$KRITA_FILENAME"
-    
+
     echo "Extracting AppImage..."
     if [ -d "squashfs-root" ]; then
         echo "Removing existing squashfs-root directory..."


### PR DESCRIPTION
This PR improves the installation script's reliability and error handling by:

1. Using the official Krita stable release URL instead of parsing from binary-factory
2. Adding proper error handling and exit conditions
3. Adding directory existence checks and cleanup
4. Ensuring proper creation of desktop integration directories
5. Improving user feedback during installation

Changes made:
```sh
# Old: Parsing URL from binary-factory
BASE_KRITA_URL="https://binary-factory.kde.org/job/Krita_Stable_Appimage_Build/lastSuccessfulBuild/artifact/"
KRITA_PAGE=$(curl -s $BASE_KRITA_URL)
LATEST_KRITA_APPIMAGE=$(echo "$KRITA_PAGE" | grep -o 'krita-.*\.appimage"' | head -1 | sed 's/"$//')

# New: Direct stable release URL
KRITA_VERSION="5.2.6"
KRITA_URL="https://download.kde.org/stable/krita/${KRITA_VERSION}/krita-${KRITA_VERSION}-x86_64.appimage"
KRITA_FILENAME="krita-${KRITA_VERSION}-x86_64.appimage"
```

```sh
# Added error handling
set -e  # Exit on error

# Added directory cleanup
if [ -d "squashfs-root" ]; then
    echo "Removing existing squashfs-root directory..."
    rm -rf squashfs-root
fi

# Added directory checks
if [ ! -d "squashfs-root" ]; then
    echo "Error: AppImage extraction failed - squashfs-root directory not found"
    exit 1
fi

# Added desktop directory creation
mkdir -p ~/.local/share/applications/
```

Testing:
- Verified Krita download and installation
- Verified plugin installation

Demo:
[Screencast From 2024-12-20 08-06-29.webm](https://github.com/user-attachments/assets/c796950f-819f-49ab-ba8c-23944b533a58)


Note: The script now uses **Krita version 5.2.6**. This version number might need to be updated periodically as new releases become available.